### PR TITLE
Fix up the ubports/ path for the ubp remote

### DIFF
--- a/fairphone/fairphone_fp2.xml
+++ b/fairphone/fairphone_fp2.xml
@@ -1,4 +1,3 @@
-<project path="kernel/fairphone/FP2" name="android_kernel_fairphone_fp2" remote="ubp" />
-<project path="device/fairphone/FP2" name="android_device_fairphone_fp2" remote="ubp" /> 
+<project path="kernel/fairphone/FP2" name="ubports/android_kernel_fairphone_fp2" remote="ubp" />
+<project path="device/fairphone/FP2" name="ubports/android_device_fairphone_fp2" remote="ubp" /> 
 <project path="device/qcom/common" name="android_device_qcom_common" remote="cm" />
-

--- a/fairphone/fairphone_fp2.xml
+++ b/fairphone/fairphone_fp2.xml
@@ -1,3 +1,3 @@
 <project path="kernel/fairphone/FP2" name="ubports/android_kernel_fairphone_fp2" remote="ubp" />
-<project path="device/fairphone/FP2" name="ubports/android_device_fairphone_fp2" remote="ubp" /> 
+<project path="device/fairphone/FP2" name="ubports/android_device_fairphone_fp2" remote="ubp" />
 <project path="device/qcom/common" name="android_device_qcom_common" remote="cm" />

--- a/lge/lge_hammerhead.xml
+++ b/lge/lge_hammerhead.xml
@@ -1,2 +1,2 @@
 <project path="device/lge/hammerhead" name="ubports/android_device_lge_hammerhead" remote="ubp" />
-<project path="kernel/lge/hammerhead" name="ubports/android_kernel_lge_hammerhead" remote="ubp" /> 
+<project path="kernel/lge/hammerhead" name="ubports/android_kernel_lge_hammerhead" remote="ubp" />

--- a/lge/lge_hammerhead.xml
+++ b/lge/lge_hammerhead.xml
@@ -1,2 +1,2 @@
-<project path="device/lge/hammerhead" name="android_device_lge_hammerhead" remote="ubp" />
-<project path="kernel/lge/hammerhead" name="android_kernel_lge_hammerhead" remote="ubp" /> 
+<project path="device/lge/hammerhead" name="ubports/android_device_lge_hammerhead" remote="ubp" />
+<project path="kernel/lge/hammerhead" name="ubports/android_kernel_lge_hammerhead" remote="ubp" /> 

--- a/oneplus/oneplus_bacon.xml
+++ b/oneplus/oneplus_bacon.xml
@@ -1,4 +1,4 @@
-<project path="device/oneplus/bacon" name="android_device_oneplus_bacon-1" remote="ubp"/>
-<project path="kernel/oneplus/msm8974" name="android_kernel_oneplus_msm8974" remote="ubp"/>
-<project path="device/oppo/common" name="android_device_oppo_common" remote="ubp"   />
+<project path="device/oneplus/bacon" name="ubports/android_device_oneplus_bacon-1" remote="ubp"/>
+<project path="kernel/oneplus/msm8974" name="ubports/android_kernel_oneplus_msm8974" remote="ubp"/>
+<project path="device/oppo/common" name="ubports/android_device_oppo_common" remote="ubp"   />
 <project path="device/qcom/common" name="android_device_qcom_common" remote="cm"   />


### PR DESCRIPTION
The ubp remote has been changed to reflect github.com rather than github.com/ubports